### PR TITLE
Improve input validation for time intervals

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -74,6 +74,11 @@ async function runImporter(intervalMs) {
 function convertToMs(interval) {
   const time = parseInt(interval.slice(0, -1), 10);
   const unit = interval.slice(-1);
+
+  if (!Number.isInteger(time) || time <= 0) {
+    throw new Error('Invalid time value. Use a positive integer followed by m, h, or d.');
+  }
+
   switch (unit) {
     case 'm':
       return time * 60 * 1000;

--- a/test/importer.test.js
+++ b/test/importer.test.js
@@ -13,6 +13,10 @@ describe('convertToMs', () => {
   test('throws on invalid unit', () => {
     expect(() => convertToMs('5x')).toThrow();
   });
+  test('throws on invalid time value', () => {
+    expect(() => convertToMs('0h')).toThrow('Invalid time value');
+    expect(() => convertToMs('h')).toThrow('Invalid time value');
+  });
 });
 
 describe('validateEnv', () => {


### PR DESCRIPTION
## Summary
- ensure `convertToMs` rejects non‑numeric or non‑positive time inputs
- verify new validation with additional Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb5e08c9c832ab94d1d1780c6310c